### PR TITLE
Migrate dev workflow to Docker Compose

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -8,8 +8,9 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
     paths:
-      - 'Dockerfile.*'
+      - 'Dockerfile.prod'
       - '.hadolint.yaml'
+      - '.github/workflows/hadolint.yml'
 
 permissions:
   contents: read
@@ -25,5 +26,5 @@ jobs:
       - name: Run hadolint
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
-          dockerfile: "Dockerfile.*"
+          dockerfile: Dockerfile.prod
           failure-threshold: error

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 # Docker files
 Dockerfile.dev
 docker-entrypoint.sh
+.env

--- a/Dockerfile.dev.dockerignore
+++ b/Dockerfile.dev.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+*
+
+# Allow only files needed for Docker build
+!docker-entrypoint.sh

--- a/Dockerfile.prod.dockerignore
+++ b/Dockerfile.prod.dockerignore
@@ -9,4 +9,3 @@
 !index.html
 !src/
 !public/
-!docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Assumes the host is macOS with Docker Desktop.
 ### 1. Download the Dockerfile and entrypoint
 
 ```sh
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.5/Dockerfile.dev
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.5/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.9/Dockerfile.dev
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.9/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,43 +2,31 @@
 
 Assumes the host is macOS with Docker Desktop.
 
-### 1. Download the Dockerfile and entrypoint
+### 1. Run setup (first time / after `hello-javascript` tag bump)
 
 ```sh
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.9/Dockerfile.dev
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.9/docker-entrypoint.sh
-chmod 755 docker-entrypoint.sh
+./setup.sh
 ```
 
-### 2. Build the image
+Fetches `Dockerfile.dev` and `docker-entrypoint.sh` from `uraitakahito/hello-javascript@1.2.9` and writes a local `.env` (`USER_ID` / `GROUP_ID` / `TZ`).
+
+### 2. Start the dev stack
 
 ```sh
-PROJECT=$(basename `pwd`) && docker image build -f Dockerfile.dev -t $PROJECT-image . --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
+GH_TOKEN=$(gh auth token) docker compose -f compose.dev.yaml up -d --build
 ```
 
-### 3. (First time only) Create a volume for shell history
+`GH_TOKEN` is intentionally not stored in `.env`; pass it via prefix every time. Omitting it just leaves `gh` / Claude Code unauthenticated inside the container.
+
+### 3. Attach to the container
+
+Either attach VS Code via **Command Palette → "Dev Containers: Attach to Running Container"** → pick `hello-typescript-vite-container` → open `/app`, or use a shell:
 
 ```sh
-docker volume create $PROJECT-zsh-history
+docker exec -it hello-typescript-vite-container zsh
 ```
 
-### 4. Start the container
-
-`-p 5173:5173` publishes the Vite dev server port so the page is reachable from the host. The `ssh-auth.sock` mount is the Docker Desktop for Mac virtual socket used to forward the host ssh-agent.
-
-```sh
-docker container run -d --rm --init -p 5173:5173 -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
-```
-
-### 5. Attach to the container via VS Code
-
-1. Open **Command Palette** (Shift + Command + P)
-2. Select **Dev Containers: Attach to Running Container**
-3. Open the `/app` directory
-
-See the [VS Code documentation](https://code.visualstudio.com/docs/devcontainers/attach-container#_attach-to-a-docker-container) for details.
-
-### 6. (First time only) Fix history volume ownership
+### 4. (First time only) Fix history volume ownership
 
 Inside the container:
 
@@ -46,7 +34,7 @@ Inside the container:
 sudo chown -R $(id -u):$(id -g) /zsh-volume
 ```
 
-### 7. Install dependencies and start the dev server
+### 5. Install dependencies and start the dev server
 
 Inside the container:
 
@@ -56,6 +44,12 @@ npm run dev
 ```
 
 Open http://localhost:5173/ on the host to see the main page, and http://localhost:5173/src/hoge.html for the `hoge` entry.
+
+### Stop
+
+```sh
+docker compose -f compose.dev.yaml down
+```
 
 ## Lint
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,27 @@
+services:
+  hello-typescript-vite:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        user_id: ${USER_ID}
+        group_id: ${GROUP_ID}
+        TZ: ${TZ:-Asia/Tokyo}
+    container_name: hello-typescript-vite-container
+    init: true
+    ports:
+      - "5173:5173"
+    volumes:
+      - .:/app
+      - zsh-history:/zsh-volume
+      - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+      - TERM=${TERM}
+      - GH_TOKEN=${GH_TOKEN}
+    tty: true
+    stdin_open: true
+
+volumes:
+  zsh-history:
+    name: hello-typescript-vite-zsh-history

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+HELLO_JS_TAG="1.2.9"
+BASE_URL="https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/${HELLO_JS_TAG}"
+
+echo "==> Fetching Dockerfile.dev and docker-entrypoint.sh from hello-javascript@${HELLO_JS_TAG}"
+curl -LfsS -o Dockerfile.dev "${BASE_URL}/Dockerfile.dev"
+curl -LfsS -o docker-entrypoint.sh "${BASE_URL}/docker-entrypoint.sh"
+chmod 755 docker-entrypoint.sh
+
+echo "==> Generating .env"
+cat > .env <<EOF
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+TZ=Asia/Tokyo
+EOF
+
+cat <<'EOF'
+
+==> Done.
+
+Next:
+  GH_TOKEN=$(gh auth token) docker compose -f compose.dev.yaml up -d --build
+
+Then attach VSCode to "hello-typescript-vite-container", or:
+  docker exec -it hello-typescript-vite-container zsh
+EOF


### PR DESCRIPTION
## Summary

- Replace the manual `docker build` / `docker volume create` / `docker run` flow in `README.md` with `./setup.sh` + `docker compose -f compose.dev.yaml up -d --build`, mirroring the [`uraitakahito/browserhive`](https://github.com/uraitakahito/browserhive) layout
- Eliminates the long-standing duplication between `README.md` and the upstream `Dockerfile.dev` header (both used to spell out the same build/run commands)
- `setup.sh` fetches `Dockerfile.dev` / `docker-entrypoint.sh` from `uraitakahito/hello-javascript@1.2.9` and writes a local `.env` (`USER_ID` / `GROUP_ID` / `TZ`)
- Splits `.dockerignore` into per-Dockerfile allow-lists (`Dockerfile.dev.dockerignore`, `Dockerfile.prod.dockerignore`) so BuildKit auto-selects per build target
- Also rolls in the prior commit that bumped the `hello-javascript` reference to `1.2.9` (now consumed by `setup.sh`)

## Test plan

- [x] `./setup.sh` fetches `Dockerfile.dev` / `docker-entrypoint.sh` and writes `.env`
- [x] `GH_TOKEN=$(gh auth token) docker compose -f compose.dev.yaml up -d --build` builds the image and starts the container with `5173:5173` published
- [x] Inside container: `npm ci && npm run dev` serves `http://localhost:5173/` and `http://localhost:5173/src/hoge.html` (HTTP 200 each)
- [x] `docker compose -f compose.dev.yaml down` cleanly tears the stack down
- [x] `docker image build -f Dockerfile.prod -t hello-typescript-vite-prod-image .` succeeds with the renamed `Dockerfile.prod.dockerignore`
- [x] Production nginx container serves both entries on port 8080 (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)