### PR TITLE
Add prod Docker Compose stack and split dev/prod docs

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-# See README.md "Production (Docker)" section for build/run instructions.
+# See docs/production-environment.md for build/run instructions.
 
 # --- Build stage ---
 FROM node:24-bookworm-slim AS build

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,18 +1,4 @@
-# Features of this Dockerfile
-#
-# - Multi-stage build: installs npm dependencies and builds the Vite app in a build stage,
-#   then copies the static output into an nginx runtime image.
-# - Runtime is nginx:alpine serving the built assets from /usr/share/nginx/html.
-#
-# Build the Docker image:
-#
-#   PROJECT=$(basename `pwd`) && docker image build -f Dockerfile.prod -t $PROJECT-prod-image .
-#
-# Run the Docker container:
-#
-#   docker container run --rm -p 8080:80 --name $PROJECT-prod-container $PROJECT-prod-image
-#
-# Then open http://localhost:8080
+# See README.md "Production (Docker)" section for build/run instructions.
 
 # --- Build stage ---
 FROM node:24-bookworm-slim AS build

--- a/README.md
+++ b/README.md
@@ -1,72 +1,25 @@
-## Development
+## Setup
 
-Assumes the host is macOS with Docker Desktop.
+### Prerequisites
 
-### 1. Run setup (first time / after `hello-javascript` tag bump)
+Run the setup script:
 
 ```sh
 ./setup.sh
 ```
 
-### 2. Start the dev stack
+### Development Environment
 
-```sh
-GH_TOKEN=$(gh auth token) docker compose -f compose.dev.yaml up -d --build
-```
+See [docs/development-environment.md](docs/development-environment.md).
 
-### 3. Attach to the container
+### Production Environment
 
-Either attach VS Code via **Command Palette → "Dev Containers: Attach to Running Container"** → pick `hello-typescript-vite-container` → open `/app`, or use a shell:
-
-```sh
-docker exec -it hello-typescript-vite-container zsh
-```
-
-### 4. (First time only) Fix history volume ownership
-
-Inside the container:
-
-```sh
-sudo chown -R $(id -u):$(id -g) /zsh-volume
-```
-
-### 5. Install dependencies and start the dev server
-
-Inside the container:
-
-```sh
-npm ci
-npm run dev
-```
-
-Open http://localhost:5173/ on the host to see the main page, and http://localhost:5173/src/hoge.html for the `hoge` entry.
-
-### Stop
-
-```sh
-docker compose -f compose.dev.yaml down
-```
+See [docs/production-environment.md](docs/production-environment.md).
 
 ## Lint
 
 ```console
 npm run lint
-```
-
-## Production (Docker)
-
-Build and run the static site via nginx.
-
-```sh
-docker compose -f compose.prod.yaml up -d --build
-```
-
-Open http://localhost:8080.
-
-### Stop
-
-```sh
-docker compose -f compose.prod.yaml down
 ```
 
 ## NOTE

--- a/README.md
+++ b/README.md
@@ -57,15 +57,17 @@ npm run lint
 
 Build and run the static site via nginx.
 
-```console
-PROJECT=$(basename `pwd`)
-docker image build -f Dockerfile.prod -t ${PROJECT}-prod-image .
-docker container run --rm -p 8080:80 --name ${PROJECT}-prod-container ${PROJECT}-prod-image
+```sh
+docker compose -f compose.prod.yaml up -d --build
 ```
 
 Open http://localhost:8080.
 
-See `Dockerfile.prod` header for details.
+### Stop
+
+```sh
+docker compose -f compose.prod.yaml down
+```
 
 ## NOTE
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,3 +1,5 @@
+name: hello-typescript-vite-dev
+
 services:
   hello-typescript-vite:
     build:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,23 @@
+name: hello-typescript-vite-prod
+
+services:
+  hello-typescript-vite:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    image: hello-typescript-vite:prod
+    container_name: hello-typescript-vite-prod
+    init: true
+    ports:
+      - "8080:80"
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx
+      - /var/run
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -1,0 +1,42 @@
+# Development Environment
+
+Assumes the host is macOS with Docker Desktop.
+
+## Start the dev stack
+
+```sh
+GH_TOKEN=$(gh auth token) docker compose -f compose.dev.yaml up -d --build
+```
+
+## Attach to the container
+
+Either attach VS Code via **Command Palette → "Dev Containers: Attach to Running Container"** → pick `hello-typescript-vite-container` → open `/app`, or use a shell:
+
+```sh
+docker exec -it hello-typescript-vite-container zsh
+```
+
+## (First time only) Fix history volume ownership
+
+Inside the container:
+
+```sh
+sudo chown -R $(id -u):$(id -g) /zsh-volume
+```
+
+## Install dependencies and start the dev server
+
+Inside the container:
+
+```sh
+npm ci
+npm run dev
+```
+
+Open <http://localhost:5173/> on the host to see the main page, and <http://localhost:5173/src/hoge.html> for the `hoge` entry.
+
+## Stop
+
+```sh
+docker compose -f compose.dev.yaml down
+```

--- a/docs/production-environment.md
+++ b/docs/production-environment.md
@@ -1,0 +1,24 @@
+# Production Environment
+
+`compose.prod.yaml` builds the Vite app via a multi-stage Docker build and serves the static output through `nginx:alpine`. The container runs read-only (with `tmpfs` mounts for `/var/cache/nginx` and `/var/run`), is health-probed via `wget --spider`, and uses `restart: unless-stopped`.
+
+```sh
+docker compose -f compose.prod.yaml up -d --build
+
+# verify
+curl -fsSI http://localhost:8080/
+```
+
+Open <http://localhost:8080/> for the main entry and <http://localhost:8080/src/hoge.html> for the `hoge` entry.
+
+Stop with:
+
+```sh
+docker compose -f compose.prod.yaml down
+```
+
+To build the production image standalone (e.g. to push to a registry):
+
+```sh
+docker build -f Dockerfile.prod -t hello-typescript-vite:<version> .
+```


### PR DESCRIPTION
## Summary

- Add `compose.prod.yaml` so the production stack mirrors the dev workflow: multi-stage Vite build via `Dockerfile.prod` served by `nginx:alpine`, with `read_only: true` + `tmpfs` mounts on `/var/cache/nginx` and `/var/run`, a `wget --spider` healthcheck, and `restart: unless-stopped`.
- Set explicit top-level `name:` on `compose.dev.yaml` (`hello-typescript-vite-dev`) and `compose.prod.yaml` (`hello-typescript-vite-prod`) so the two files don't share an implicit project name and stomp on each other's containers when switching with `-f`.
- Move dev/prod setup instructions out of `README.md` into `docs/development-environment.md` and `docs/production-environment.md`, mirroring the `uraitakahito/browserhive` layout. README's Setup section now just links to those docs.

## Test plan

- [x] `docker compose -f compose.prod.yaml up -d --build` builds and starts cleanly
- [x] `curl -fsSI http://localhost:8080/` returns `HTTP/1.1 200 OK` (main entry)
- [x] `curl -fsSI http://localhost:8080/src/hoge.html` returns `HTTP/1.1 200 OK` (hoge entry)
- [x] `docker inspect --format='{{.State.Health.Status}}' hello-typescript-vite-prod` reaches `healthy`
- [x] nginx starts cleanly under `read_only: true` (workers spawn, tmpfs covers the writable paths)
- [x] dev (`5173`) and prod (`8080`) can run concurrently without `-p` flags now that project names are distinct
- [x] `docker compose -f compose.prod.yaml down` removes container + network

🤖 Generated with [Claude Code](https://claude.com/claude-code)